### PR TITLE
Add react/jsx-no-target-blank rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,6 +206,7 @@ module.exports = {
         "afterOpening": "never"
       }
     ],
+    "react/jsx-no-target-blank": 2,
 
     "import/order": [2, {
       "newlines-between": "always"


### PR DESCRIPTION
According to [this audit](https://developers.google.com/web/tools/lighthouse/audits/noopener) it requires to add rel="noopener" or rel="noreferrer" when you use target="_blank"